### PR TITLE
remove errno usage

### DIFF
--- a/adafruit_pathlib.py
+++ b/adafruit_pathlib.py
@@ -350,7 +350,7 @@ class Path:
             OSError: If self.is_dir() is False.
         """
         if not self.is_dir():
-            raise OSError(errno.ENOTDIR, f"Not a directory: {self._path}")
+            raise OSError(f"Not a directory: {self._path}")
         for name in os.listdir(self._path):
             yield Path(self._path, name)
 


### PR DESCRIPTION
@tannewt I think this errorno was added as part of the core pathlib PR perhaps. I had been using that core pathlib build last time I worked on the launcher, and have updated now to absolute newest without core pathlib. 

Let me know if we should add this constant somewhere else instead of removing its usage from here. 